### PR TITLE
[Validator][Date] Add format option

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Date.php
+++ b/src/Symfony/Component/Validator/Constraints/Date.php
@@ -23,38 +23,31 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Date extends Constraint
 {
-    public const PATTERN_YMD = '/^Y(?<separator1>[.\-\/])m(?<separator2>[.\-\/])d$/D';
-    public const PATTERN_MDY = '/^m(?<separator1>[.\-\/])d(?<separator2>[.\-\/])Y$/D';
-    public const PATTERN_DMY = '/^d(?<separator1>[.\-\/])m(?<separator2>[.\-\/])Y$/D';
-
-    public const ACCEPTED_DATE_FORMATS_REGEX = [
-        'Y[.-/]m[.-/]d' => self::PATTERN_YMD,
-        'm[.-/]d[.-/]Y' => self::PATTERN_MDY,
-        'd[.-/]m[.-/]Y' => self::PATTERN_DMY,
-    ];
-
     public const INVALID_FORMAT_ERROR = '69819696-02ac-4a99-9ff0-14e127c4d1bc';
     public const INVALID_DATE_ERROR = '3c184ce5-b31d-4de7-8b76-326da7b2be93';
-    public const NOT_SUPPORTED_DATE_FORMAT_ERROR = 'c9627b80-89b7-4ca6-8b29-a1e709c0ca90';
 
     protected const ERROR_NAMES = [
         self::INVALID_FORMAT_ERROR => 'INVALID_FORMAT_ERROR',
         self::INVALID_DATE_ERROR => 'INVALID_DATE_ERROR',
-        self::NOT_SUPPORTED_DATE_FORMAT_ERROR => 'NOT_SUPPORTED_DATE_FORMAT_ERROR',
     ];
 
     public string $format = 'Y-m-d';
     public string $message = 'This value is not a valid date.';
-    public string $messageDateFormatNotAccepted = 'Unsupported format "{{ value }}", only {{ formats }} are supported, with same separators.';
 
     /**
      * @param array<string,mixed>|null $options
      * @param string[]|null            $groups
      */
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, mixed $payload = null)
-    {
+    public function __construct(
+        ?array $options = null,
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+        ?string $format = null,
+    ) {
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;
+        $this->format = $format ?? $this->format;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Date.php
+++ b/src/Symfony/Component/Validator/Constraints/Date.php
@@ -23,16 +23,14 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Date extends Constraint
 {
-    public const ACCEPTED_DATE_FORMATS = [
-        'Y-m-d',
-        'm-d-Y',
-        'd-m-Y',
-        'Y/m/d',
-        'm/d/Y',
-        'd/m/Y',
-        'Y.m.d',
-        'm.d.Y',
-        'd.m.Y',
+    public const PATTERN_YMD = '/^Y(?<separator1>[.\-\/])m(?<separator2>[.\-\/])d$/D';
+    public const PATTERN_MDY = '/^m(?<separator1>[.\-\/])d(?<separator2>[.\-\/])Y$/D';
+    public const PATTERN_DMY = '/^d(?<separator1>[.\-\/])m(?<separator2>[.\-\/])Y$/D';
+
+    public const ACCEPTED_DATE_FORMATS_REGEX = [
+        'Y[.-/]m[.-/]d' => self::PATTERN_YMD,
+        'm[.-/]d[.-/]Y' => self::PATTERN_MDY,
+        'd[.-/]m[.-/]Y' => self::PATTERN_DMY,
     ];
 
     public const INVALID_FORMAT_ERROR = '69819696-02ac-4a99-9ff0-14e127c4d1bc';
@@ -47,7 +45,7 @@ class Date extends Constraint
 
     public string $format = 'Y-m-d';
     public string $message = 'This value is not a valid date.';
-    public string $messageDateFormatNotAccepted = 'This format "{{ value }}" is not supported, availabl : {{ formats }}.';
+    public string $messageDateFormatNotAccepted = 'Unsupported format "{{ value }}", only {{ formats }} are supported, with same separators.';
 
     /**
      * @param array<string,mixed>|null $options

--- a/src/Symfony/Component/Validator/Constraints/Date.php
+++ b/src/Symfony/Component/Validator/Constraints/Date.php
@@ -23,15 +23,31 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Date extends Constraint
 {
+    public const ACCEPTED_DATE_FORMATS = [
+        'Y-m-d',
+        'm-d-Y',
+        'd-m-Y',
+        'Y/m/d',
+        'm/d/Y',
+        'd/m/Y',
+        'Y.m.d',
+        'm.d.Y',
+        'd.m.Y',
+    ];
+
     public const INVALID_FORMAT_ERROR = '69819696-02ac-4a99-9ff0-14e127c4d1bc';
     public const INVALID_DATE_ERROR = '3c184ce5-b31d-4de7-8b76-326da7b2be93';
+    public const NOT_SUPPORTED_DATE_FORMAT_ERROR = 'c9627b80-89b7-4ca6-8b29-a1e709c0ca90';
 
     protected const ERROR_NAMES = [
         self::INVALID_FORMAT_ERROR => 'INVALID_FORMAT_ERROR',
         self::INVALID_DATE_ERROR => 'INVALID_DATE_ERROR',
+        self::NOT_SUPPORTED_DATE_FORMAT_ERROR => 'NOT_SUPPORTED_DATE_FORMAT_ERROR',
     ];
 
+    public string $format = 'Y-m-d';
     public string $message = 'This value is not a valid date.';
+    public string $messageDateFormatNotAccepted = 'This format "{{ value }}" is not supported, availabl : {{ formats }}.';
 
     /**
      * @param array<string,mixed>|null $options

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -37,10 +37,21 @@ class DateValidator extends ConstraintValidator
 
         $value = (string) $value;
 
-        if (!\in_array($constraint->format, Date::ACCEPTED_DATE_FORMATS)) {
+        $formatValid = false;
+
+        foreach (Date::ACCEPTED_DATE_FORMATS_REGEX as $regexFormatAccepted) {
+            if (preg_match($regexFormatAccepted, $constraint->format, $matches)
+                && $matches['separator1'] === $matches['separator2']
+            ) {
+                $formatValid = true;
+                break;
+            }
+        }
+
+        if (false === $formatValid) {
             $this->context->buildViolation($constraint->messageDateFormatNotAccepted)
                 ->setParameter('{{ value }}', $this->formatValue($constraint->format))
-                ->setParameter('{{ formats }}', $this->formatValues(Date::ACCEPTED_DATE_FORMATS))
+                ->setParameter('{{ formats }}', $this->formatValues(array_keys(Date::ACCEPTED_DATE_FORMATS_REGEX)))
                 ->setCode(Date::NOT_SUPPORTED_DATE_FORMAT_ERROR)
                 ->addViolation();
 

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -37,27 +37,6 @@ class DateValidator extends ConstraintValidator
 
         $value = (string) $value;
 
-        $formatValid = false;
-
-        foreach (Date::ACCEPTED_DATE_FORMATS_REGEX as $regexFormatAccepted) {
-            if (preg_match($regexFormatAccepted, $constraint->format, $matches)
-                && $matches['separator1'] === $matches['separator2']
-            ) {
-                $formatValid = true;
-                break;
-            }
-        }
-
-        if (false === $formatValid) {
-            $this->context->buildViolation($constraint->messageDateFormatNotAccepted)
-                ->setParameter('{{ value }}', $this->formatValue($constraint->format))
-                ->setParameter('{{ formats }}', $this->formatValues(array_keys(Date::ACCEPTED_DATE_FORMATS_REGEX)))
-                ->setCode(Date::NOT_SUPPORTED_DATE_FORMAT_ERROR)
-                ->addViolation();
-
-            return;
-        }
-
         $asDateTimeImmutable = \DateTimeImmutable::createFromFormat($constraint->format, $value);
 
         if (!$asDateTimeImmutable) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -130,7 +130,7 @@ class DateValidatorTest extends ConstraintValidatorTestCase
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$format.'"')
-            ->setParameter('{{ formats }}', '"Y-m-d", "m-d-Y", "d-m-Y", "Y/m/d", "m/d/Y", "d/m/Y", "Y.m.d", "m.d.Y", "d.m.Y"')
+            ->setParameter('{{ formats }}', '"Y[.-/]m[.-/]d", "m[.-/]d[.-/]Y", "d[.-/]m[.-/]Y"')
             ->setCode($code)
             ->assertRaised();
     }
@@ -141,6 +141,9 @@ class DateValidatorTest extends ConstraintValidatorTestCase
             ['2010-12-20', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'Y-m-Y'],
             ['2010-04-30', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'm-m-Y'],
             ['2010-02-29', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'foo'],
+            ['01.05.2030', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'd.m/Y'],
+            ['01.05.2030', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'd/m-Y'],
+            ['01.05.2030', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'd/m.Y'],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -117,47 +117,43 @@ class DateValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @dataProvider getInvalidFormats
+     * @dataProvider getNotMatchingDatesAndFormats
      */
-    public function testInvalidFormats($date, $code, $format)
+    public function testInvalidFormats($date, $format, $code)
     {
-        $constraint = new Date([
-            'messageDateFormatNotAccepted' => 'myMessage',
-            'format' => $format,
-        ]);
+        $constraint = new Date(message: 'myMessage', format: $format);
 
         $this->validator->validate($date, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', '"'.$format.'"')
-            ->setParameter('{{ formats }}', '"Y[.-/]m[.-/]d", "m[.-/]d[.-/]Y", "d[.-/]m[.-/]Y"')
+            ->setParameter('{{ value }}', '"'.$date.'"')
             ->setCode($code)
             ->assertRaised();
     }
 
-    public static function getInvalidFormats()
+    public static function getNotMatchingDatesAndFormats(): array
     {
         return [
-            ['2010-12-20', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'Y-m-Y'],
-            ['2010-04-30', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'm-m-Y'],
-            ['2010-02-29', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'foo'],
-            ['01.05.2030', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'd.m/Y'],
-            ['01.05.2030', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'd/m-Y'],
-            ['01.05.2030', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'd/m.Y'],
+            ['2010-03-24', 'm-m-Y', Date::INVALID_FORMAT_ERROR],
+            ['2010-02-29', 'foo', Date::INVALID_FORMAT_ERROR],
+            ['bob', 'Y-m-d', Date::INVALID_FORMAT_ERROR],
+            ['01.05.2030', 'd.m/Y', Date::INVALID_FORMAT_ERROR],
+            ['01.05.2030', 'd/m-Y', Date::INVALID_FORMAT_ERROR],
+            ['01.05.2030', 'd/m.Y', Date::INVALID_FORMAT_ERROR],
         ];
     }
 
     /**
-     * @dataProvider getValidFormats
+     * @dataProvider getMatchingDatesAndFormats
      */
     public function testValidFormats($date, $format)
     {
-        $this->validator->validate($date, new Date(['format' => $format]));
+        $this->validator->validate($date, new Date(format: $format));
 
         $this->assertNoViolation();
     }
 
-    public static function getValidFormats()
+    public static function getMatchingDatesAndFormats(): array
     {
         return [
             ['2010-01-01', 'Y-m-d'],
@@ -169,6 +165,8 @@ class DateValidatorTest extends ConstraintValidatorTestCase
             ['2010.01.01', 'Y.m.d'],
             ['12.11.2010', 'm.d.Y'],
             ['01.05.2030', 'd.m.Y'],
+            ['01.05/2030', 'd.m/Y'],
+            ['December 31, 1999', 'F d, Y'],
         ];
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -115,4 +115,57 @@ class DateValidatorTest extends ConstraintValidatorTestCase
             ['2010-02-29', Date::INVALID_DATE_ERROR],
         ];
     }
+
+    /**
+     * @dataProvider getInvalidFormats
+     */
+    public function testInvalidFormats($date, $code, $format)
+    {
+        $constraint = new Date([
+            'messageDateFormatNotAccepted' => 'myMessage',
+            'format' => $format,
+        ]);
+
+        $this->validator->validate($date, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$format.'"')
+            ->setParameter('{{ formats }}', '"Y-m-d", "m-d-Y", "d-m-Y", "Y/m/d", "m/d/Y", "d/m/Y", "Y.m.d", "m.d.Y", "d.m.Y"')
+            ->setCode($code)
+            ->assertRaised();
+    }
+
+    public static function getInvalidFormats()
+    {
+        return [
+            ['2010-12-20', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'Y-m-Y'],
+            ['2010-04-30', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'm-m-Y'],
+            ['2010-02-29', Date::NOT_SUPPORTED_DATE_FORMAT_ERROR, 'foo'],
+        ];
+    }
+
+    /**
+     * @dataProvider getValidFormats
+     */
+    public function testValidFormats($date, $format)
+    {
+        $this->validator->validate($date, new Date(['format' => $format]));
+
+        $this->assertNoViolation();
+    }
+
+    public static function getValidFormats()
+    {
+        return [
+            ['2010-01-01', 'Y-m-d'],
+            ['12-12-1955', 'm-d-Y'],
+            ['31-05-2030', 'd-m-Y'],
+            ['2010/01/01', 'Y/m/d'],
+            ['12/12/1955', 'm/d/Y'],
+            ['31/05/2030', 'd/m/Y'],
+            ['2010.01.01', 'Y.m.d'],
+            ['12.11.2010', 'm.d.Y'],
+            ['01.05.2030', 'd.m.Y'],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT


Hi everyone,

Add support of `format` option for the `Date` constraint :

- Y[.-/]m[.-/]d (the default)
- d[.-/]m[.-/]Y
- m[.-/]d[.-/]Y

Don't hesitate to make any suggestions